### PR TITLE
Update pom.xml

### DIFF
--- a/spring-boot-integration-tests/spring-boot-gradle-tests/pom.xml
+++ b/spring-boot-integration-tests/spring-boot-gradle-tests/pom.xml
@@ -75,7 +75,7 @@
 	<repositories>
 		<repository>
 			<id>gradle</id>
-			<url>http://repo.gradle.org/gradle/libs-releases-local</url>
+			<url>https://repo.gradle.org/gradle/libs-releases-local</url>
 			<releases>
 				<enabled>true</enabled>
 			</releases>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring Boot. Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #).
-->

new repo url uses https. when building my project I get 
Could not transfer artifact org.gradle:gradle-core:pom:1.12 from/to gradle (http://repo.gradle.org/gradle/libs-releases-local): Authorization failed for http://repo.gradle.org/gradle/libs-releases-local/org/gradle/gradle-core/1.12/gradle-core-1.12.pom 403 Forbidden -> [Help 1]